### PR TITLE
feat: add pm-data skill — quantitative analytics layer with PostHog, Amplitude, and pipeline integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Autonomous PM skill pack for Claude Code. Replaces the PM workflow end-to-end.
 | pm-interview | `/pm-interview` | Prepare and debrief user interviews, update FEEDBACK.md |
 | pm-standup | `/pm-standup` | Daily briefing — what shipped, today's priorities, blockers |
 | pm-weekly-update | `/pm-weekly-update` | Draft stakeholder update email, adapted to audience |
+| pm-data | `/pm-data` | Answer a product question with PostHog or Amplitude data — trends, funnels, retention |
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ Autonomous PM skill pack for Claude Code. Replaces the PM workflow end-to-end.
 | pm-prd | `/pm-prd` | Full PRD (or Shape Up pitch) |
 | pm-breakdown | `/pm-breakdown` | Break PRD into tasks, create tickets in Linear / GitHub Issues |
 | pm-retro | `/pm-retro` | Compare roadmap vs commits, surface drift |
+| pm-interview | `/pm-interview` | Prepare and debrief user interviews, update FEEDBACK.md |
+| pm-standup | `/pm-standup` | Daily briefing — what shipped, today's priorities, blockers |
+| pm-weekly-update | `/pm-weekly-update` | Draft stakeholder update email, adapted to audience |
 
 ## Architecture
 

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -35,3 +35,5 @@ That's it. No code changes needed.
 | github | `mcp__github__*` | `GITHUB_TOKEN` | github.com | Issues, PRs, releases |
 | google-calendar | `mcp__claude_ai_Google_Calendar__*` | OAuth v3 | — | Today's events, meetings |
 | granola | `mcp__claude_ai_Granola__*` | — | — | Meeting notes, transcripts |
+| posthog | `mcp__claude_ai_PostHog__*` | `POSTHOG_API_KEY` + `POSTHOG_PROJECT_ID` | — | Trends, funnels, retention, paths |
+| amplitude | — | `AMPLITUDE_API_KEY` + `AMPLITUDE_SECRET_KEY` | app.amplitude.com | Trends, funnels, retention |

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -33,3 +33,5 @@ That's it. No code changes needed.
 | notion | `mcp__notion__*` | `NOTION_API_KEY` | notion.so | Pages, databases |
 | dovetail | — | `DOVETAIL_API_KEY` | dovetail.com | Insights, themes, tags |
 | github | `mcp__github__*` | `GITHUB_TOKEN` | github.com | Issues, PRs, releases |
+| google-calendar | `mcp__claude_ai_Google_Calendar__*` | OAuth v3 | — | Today's events, meetings |
+| granola | `mcp__claude_ai_Granola__*` | — | — | Meeting notes, transcripts |

--- a/connectors/amplitude.md
+++ b/connectors/amplitude.md
@@ -1,0 +1,84 @@
+# Connector: Amplitude
+
+Fetches product analytics — event trends, funnel analysis, retention, and user segments.
+Used by `/pm-data` as an alternative or complement to PostHog.
+
+## Tier 1 (MCP)
+
+Amplitude does not currently provide an official MCP server.
+Use Tier 2 (API) instead.
+
+---
+
+## Tier 2 (API)
+
+**Detection:** `[ -n "$AMPLITUDE_API_KEY" ] && [ -n "$AMPLITUDE_SECRET_KEY" ]`
+
+**Base URL:** `https://amplitude.com/api/2/`
+
+**Authentication:** HTTP Basic Auth with API key + secret key.
+
+**Event segmentation — trend for an event:**
+```bash
+curl -s "https://amplitude.com/api/2/events/segmentation" \
+  -u "$AMPLITUDE_API_KEY:$AMPLITUDE_SECRET_KEY" \
+  -d "e=$(python3 -c "import urllib.parse,json; print(urllib.parse.quote(json.dumps({'event_type':'YOUR_EVENT'})))")" \
+  -d "start=$(date -v-30d +%Y%m%d)" \
+  -d "end=$(date +%Y%m%d)" \
+  -d "i=1"
+```
+
+**Funnel analysis:**
+```bash
+curl -s "https://amplitude.com/api/2/funnels" \
+  -u "$AMPLITUDE_API_KEY:$AMPLITUDE_SECRET_KEY" \
+  -G \
+  --data-urlencode 'e=[{"event_type":"signed_up"},{"event_type":"onboarding_completed"},{"event_type":"first_core_action"}]' \
+  -d "start=$(date -v-30d +%Y%m%d)" \
+  -d "end=$(date +%Y%m%d)"
+```
+
+**Retention:**
+```bash
+curl -s "https://amplitude.com/api/2/retention" \
+  -u "$AMPLITUDE_API_KEY:$AMPLITUDE_SECRET_KEY" \
+  -G \
+  --data-urlencode 'se={"event_type":"signed_up"}' \
+  --data-urlencode 're={"event_type":"core_action"}' \
+  -d "start=$(date -v-60d +%Y%m%d)" \
+  -d "end=$(date +%Y%m%d)"
+```
+
+**User lookup — active users in last 7 days:**
+```bash
+curl -s "https://amplitude.com/api/2/usersearch" \
+  -u "$AMPLITUDE_API_KEY:$AMPLITUDE_SECRET_KEY" \
+  -d "user=active"
+```
+
+**What to extract:**
+- Event counts + % change vs prior period
+- Funnel conversion rate per step, biggest drop-off
+- Day 1 / Day 7 / Day 30 retention
+- Active user counts (DAU, WAU, MAU)
+
+**Required env vars:** `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY`
+Get them: Amplitude → Settings → Projects → [your project] → API Keys
+
+---
+
+## Tier 3 (Browser)
+
+**Detection:** `$B` available
+
+**URL:** `https://app.amplitude.com`
+
+Navigate to the relevant chart, take a snapshot, and parse the visible numbers.
+Useful for one-off reads but unreliable for structured extraction.
+
+---
+
+## Tier 4 (Manual fallback)
+
+If no tier available, `/pm-data` asks:
+> "Paste the key metrics you have — conversion rates, DAU/MAU, retention numbers, anything. Raw numbers are fine."

--- a/connectors/google-calendar.md
+++ b/connectors/google-calendar.md
@@ -1,0 +1,66 @@
+# Connector: Google Calendar
+
+Fetches today's events and upcoming meetings from Google Calendar.
+Used by `/pm-standup` to surface the day's schedule and flag meetings that may need prep.
+
+## Tier 1 (MCP)
+
+**Detection:** `grep "mcp__claude_ai_Google_Calendar__" ~/.claude/CLAUDE.md 2>/dev/null || grep "Google_Calendar" ~/.claude/CLAUDE.md 2>/dev/null`
+
+**Read tools:**
+```
+mcp__claude_ai_Google_Calendar__gcal_list_events   — list events for a date range
+mcp__claude_ai_Google_Calendar__gcal_list_calendars — list available calendars
+mcp__claude_ai_Google_Calendar__gcal_get_event      — get full event details
+```
+
+**Fetching today's events:**
+```
+mcp__claude_ai_Google_Calendar__gcal_list_events(
+  calendar_id: "primary",
+  time_min:    "{today}T00:00:00Z",
+  time_max:    "{today}T23:59:59Z",
+  max_results: 20
+)
+```
+
+**What to extract:**
+- Event title, start time, end time, duration
+- Attendees (if present) — signals collaborative vs solo meetings
+- Meeting description / agenda (if present)
+- Location or video link (signals external vs internal)
+
+**Heuristics for `/pm-standup`:**
+- Flag meetings >1h as "heavy" — likely needs prep
+- Flag meetings with external attendees — may need context from Granola or notes
+- Cross-reference event title with recent git commits: if event topic matches a feature area with no recent commits, flag as "no recent progress on this"
+
+**Setup for users:**
+Add the Google Calendar MCP server to your Claude Code configuration.
+Once connected, events are fetched automatically — no API key needed.
+
+---
+
+## Tier 2 (API)
+
+**Detection:** `[ -n "$GOOGLE_CALENDAR_API_KEY" ]` or OAuth credentials in environment.
+
+Not recommended for this use case — MCP is simpler and more reliable for personal calendars.
+If needed: use Google Calendar API v3 `events.list` endpoint with OAuth 2.0.
+
+---
+
+## Tier 3 (Browser)
+
+Not applicable — Google Calendar browser scraping is fragile and unnecessary when MCP is available.
+
+---
+
+## Tier 4 (Manual fallback)
+
+If no tier is available, `/pm-standup` skips the meetings section and notes:
+```
+MEETINGS  (Google Calendar not connected — add MCP to see today's schedule)
+```
+
+No question is asked — standup never blocks on missing calendar data.

--- a/connectors/granola.md
+++ b/connectors/granola.md
@@ -1,0 +1,81 @@
+# Connector: Granola
+
+Fetches meeting notes and transcripts from Granola.
+Used by `/pm-standup` for recent meeting context and by `/pm-interview` to pull user interview transcripts automatically.
+
+## Tier 1 (MCP)
+
+**Detection:** `grep "mcp__claude_ai_Granola__" ~/.claude/CLAUDE.md 2>/dev/null || grep "Granola" ~/.claude/CLAUDE.md 2>/dev/null`
+
+**Read tools:**
+```
+mcp__claude_ai_Granola__list_meetings          — list recent meetings with metadata
+mcp__claude_ai_Granola__get_meetings           — get meetings with optional filters
+mcp__claude_ai_Granola__get_meeting_transcript — full transcript for a specific meeting
+mcp__claude_ai_Granola__query_granola_meetings — search meetings by keyword or topic
+mcp__claude_ai_Granola__list_meeting_folders   — list folder structure (if organized)
+```
+
+**Fetching recent meetings (for /pm-standup):**
+```
+mcp__claude_ai_Granola__list_meetings(
+  limit: 5
+)
+```
+Extract: meeting title, date, duration, participants — gives context on what was discussed recently.
+
+**Fetching a specific transcript (for /pm-interview):**
+```
+mcp__claude_ai_Granola__query_granola_meetings(
+  query: "{topic or person name}"
+)
+→ get meeting_id from results
+mcp__claude_ai_Granola__get_meeting_transcript(
+  meeting_id: "{id}"
+)
+```
+
+**What to extract for `/pm-standup`:**
+- Meetings from the last 24-48h: title, participants, key decisions if available in notes
+- Flag if a meeting has no notes yet (may need follow-up)
+
+**What to extract for `/pm-interview`:**
+- Full transcript text — feed directly into Phase 5 signal extraction
+- Participant names — identifies the interviewee profile
+- Meeting date — timestamps the interview session in FEEDBACK.md
+- Any action items or follow-ups noted in Granola
+
+**Heuristics:**
+- Meeting title contains "user", "customer", "interview", "discovery", "research", "call" → likely a user interview → suggest using `/pm-interview` to extract signal
+- Meeting title contains "standup", "sync", "weekly", "planning" → internal meeting → show in standup summary only
+- Transcript length >3000 words → rich data source, worth full signal extraction
+
+**Setup for users:**
+Add the Granola MCP server to your Claude Code configuration.
+Granola uses your local app session — no separate API key needed.
+
+---
+
+## Tier 2 (API)
+
+Granola does not currently expose a public REST API.
+Tier 1 (MCP) is the only programmatic access path.
+
+---
+
+## Tier 3 (Browser)
+
+Not applicable — Granola is a desktop app, not a web app with scrapable URLs.
+
+---
+
+## Tier 4 (Manual fallback)
+
+If Granola MCP is not available:
+
+**For `/pm-standup`:** skip the Granola section silently — no question asked.
+
+**For `/pm-interview`:** in Phase 5, ask the user to paste their raw notes manually:
+> "Granola not connected. Paste your interview notes below — transcript, bullet points, anything."
+
+This is the default Tier 4 behavior already in `/pm-interview` Phase 5.

--- a/connectors/posthog.md
+++ b/connectors/posthog.md
@@ -1,0 +1,104 @@
+# Connector: PostHog
+
+Fetches product analytics — trends, funnels, retention, session data, and feature flag usage.
+Used by `/pm-data` to answer quantitative product questions.
+
+## Tier 1 (MCP)
+
+**Detection:** `grep "mcp__claude_ai_PostHog__" ~/.claude/CLAUDE.md 2>/dev/null || grep "PostHog" ~/.claude/CLAUDE.md 2>/dev/null`
+
+**Key tools:**
+```
+mcp__claude_ai_PostHog__query-trends          — time series for any event
+mcp__claude_ai_PostHog__query-funnel          — conversion funnel between steps
+mcp__claude_ai_PostHog__query-retention       — retention cohort analysis
+mcp__claude_ai_PostHog__query-paths           — user paths through the product
+mcp__claude_ai_PostHog__query-stickiness      — how often users return to a feature
+mcp__claude_ai_PostHog__insight-query         — run a custom HogQL query
+mcp__claude_ai_PostHog__persons-list          — list users matching filters
+mcp__claude_ai_PostHog__feature-flag-get-all  — all feature flags and their status
+mcp__claude_ai_PostHog__projects-get          — current project info
+mcp__claude_ai_PostHog__switch-project        — switch active project if needed
+```
+
+**Common queries for `/pm-data`:**
+
+Trend — daily active users last 30 days:
+```
+mcp__claude_ai_PostHog__query-trends(
+  events: [{ id: "$pageview", name: "Pageview" }],
+  date_from: "-30d"
+)
+```
+
+Funnel — onboarding drop-off:
+```
+mcp__claude_ai_PostHog__query-funnel(
+  events: [
+    { id: "signed_up" },
+    { id: "onboarding_step_1_completed" },
+    { id: "onboarding_completed" },
+    { id: "first_core_action" }
+  ],
+  date_from: "-30d"
+)
+```
+
+Retention — week-over-week:
+```
+mcp__claude_ai_PostHog__query-retention(
+  target_entity: { id: "first_core_action" },
+  returning_entity: { id: "core_action" },
+  period: "Week",
+  date_from: "-12w"
+)
+```
+
+**What to extract:**
+- Trend data → absolute numbers + % change vs prior period
+- Funnel → conversion rate per step, biggest drop-off step
+- Retention → Day 1 / Day 7 / Day 30 retention rates
+- Paths → most common paths after key events (reveals unexpected user flows)
+
+**Setup for users:**
+Add the PostHog MCP server to your Claude Code configuration.
+Ensure the correct project is active with `mcp__claude_ai_PostHog__projects-get`.
+
+---
+
+## Tier 2 (API)
+
+**Detection:** `[ -n "$POSTHOG_API_KEY" ]`
+
+**Base URL:** `https://app.posthog.com/api/` (or self-hosted URL)
+
+**Trends:**
+```bash
+curl -s "https://app.posthog.com/api/projects/${POSTHOG_PROJECT_ID}/insights/trend/" \
+  -H "Authorization: Bearer $POSTHOG_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"events":[{"id":"$pageview"}],"date_from":"-30d","interval":"day"}'
+```
+
+**Funnel:**
+```bash
+curl -s "https://app.posthog.com/api/projects/${POSTHOG_PROJECT_ID}/insights/funnel/" \
+  -H "Authorization: Bearer $POSTHOG_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"events":[{"id":"signed_up"},{"id":"onboarding_completed"}],"date_from":"-30d"}'
+```
+
+**Required env vars:** `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`
+
+---
+
+## Tier 3 (Browser)
+
+Not recommended — PostHog dashboard scraping is fragile. Use Tier 1 or 2.
+
+---
+
+## Tier 4 (Manual fallback)
+
+If no tier available, `/pm-data` asks:
+> "Paste the key metrics you have — conversion rates, DAU/MAU, retention numbers, anything. Raw numbers are fine."

--- a/pm-audit/SKILL.md
+++ b/pm-audit/SKILL.md
@@ -62,6 +62,19 @@ Offer re-fetch only if last audit was >30 days ago: "Re-fetch from {url}? (y/N)"
 
 ## Phase 2: Data collection
 
+Check for DATA.md — if it exists, it contains quantitative analytics from /pm-data:
+
+```bash
+[ -f ".nanopm/DATA.md" ] && echo "DATA_EXISTS" || echo "DATA_MISSING"
+```
+
+**If DATA_EXISTS:** read `.nanopm/DATA.md`. Extract:
+- The most recent analysis question and its key insight
+- Metrics marked 🟢 high confidence — these are facts, not hypotheses
+- Any "biggest unknown" flagged — these are candidates for Section 4 (the question you're avoiding)
+
+Store these for use in Phase 4 synthesis. Only 🟢 high-confidence findings should anchor audit conclusions.
+
 Check for FEEDBACK.md first — if it exists, it's the primary feedback source and supersedes direct connector fetching for Q6:
 
 ```bash
@@ -177,6 +190,7 @@ Synthesize a first-pass understanding of:
 2. Who it's actually for (inferred, may differ from stated)
 3. The gap between stated goals (Q5) and what's been shipped (Q4)
 4. The most important feedback signal — use FEEDBACK.md top unaddressed signal if available, otherwise Q6 + connector data. If FEEDBACK.md exists, note which themes are already addressed vs. which represent genuine gaps.
+5. **If DATA_EXISTS:** fold in quantitative findings. For each 🟢 high-confidence metric: does it confirm or contradict the qualitative signal? Flag contradictions explicitly — e.g., "Users say onboarding is fine (FEEDBACK.md), but data shows 60% drop-off at step 2 (DATA.md 🟢)." Contradictions between quanti and quali are the most valuable audit findings.
 
 ## Phase 5: Adversarial self-challenge
 
@@ -247,7 +261,21 @@ pay to fix it, or is it just a nice-to-have?"]
 
 ---
 
-## 5. Recommended Next Skill
+## 5. What The Data Says
+
+{Include this section ONLY if DATA.md exists. Otherwise omit entirely.}
+
+[2-3 sentences max. The most important quantitative finding and what it means for the audit.
+Format: "{Metric} is {value} ({confidence}), which {confirms / contradicts} {qualitative signal}.
+The most important unknown the data raises: {question}."]
+
+**Action:** {If quanti contradicts quali: "Investigate the discrepancy before setting objectives."
+If quanti confirms: "Use this number to size the problem in your PRD."
+If biggest unknown is flagged: "Run /pm-interview to answer {question} before /pm-strategy."}
+
+---
+
+## 6. Recommended Next Skill
 
 **Run: /pm-{objectives|strategy|roadmap}**
 

--- a/pm-data/SKILL.md
+++ b/pm-data/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: pm-data
+version: 0.1.0
+description: "Quantitative data analysis for PMs. Answers a specific product question using PostHog or Amplitude — trends, funnels, retention, paths. Writes findings to DATA.md, consumed by /pm-audit and /pm-prd."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent, mcp__claude_ai_PostHog__query-trends, mcp__claude_ai_PostHog__query-funnel, mcp__claude_ai_PostHog__query-retention, mcp__claude_ai_PostHog__query-paths, mcp__claude_ai_PostHog__query-stickiness, mcp__claude_ai_PostHog__insight-query, mcp__claude_ai_PostHog__projects-get, mcp__claude_ai_PostHog__event-definitions-list, mcp__claude_ai_PostHog__persons-list
+---
+
+## Preamble (run first)
+
+```bash
+source ~/.nanopm/lib/nanopm.sh 2>/dev/null || \
+  source .nanopm/lib/nanopm.sh 2>/dev/null || \
+  { echo "ERROR: nanopm not installed. Run: curl -fsSL https://raw.githubusercontent.com/nmrtn/nanopm/main/setup | bash"; exit 1; }
+nanopm_preamble
+nanopm_telemetry_pending "pm-data"
+_DATA_FILE=".nanopm/DATA.md"
+```
+
+## When to run this
+
+Run `/pm-data` when:
+- You have a specific question about user behavior ("why do users drop at step 3?")
+- You're about to run /pm-audit and want quanti to back the qualitatif signal
+- You're writing a PRD and need to quantify the problem size
+- You want to check the impact of a shipped feature
+
+**One question per run.** A vague question ("how is the product doing?") produces useless output. A specific question ("what is the Day 7 retention for users who completed onboarding vs those who didn't?") produces an insight.
+
+## Phase 0: Prior context
+
+```bash
+nanopm_context_read pm-data
+nanopm_context_all
+```
+
+Check for prior DATA.md — if it exists, show a one-line summary of the last analysis and its date. Don't repeat the same analysis unless explicitly requested.
+
+```bash
+[ -f ".nanopm/DATA.md" ] && echo "DATA_EXISTS" || echo "DATA_MISSING"
+[ -f ".nanopm/AUDIT.md" ] && echo "AUDIT_EXISTS" || echo "AUDIT_MISSING"
+[ -f ".nanopm/DISCOVERY.md" ] && echo "DISCOVERY_EXISTS" || echo "DISCOVERY_MISSING"
+```
+
+If AUDIT_EXISTS: scan for "biggest gap" or "question you're avoiding" — suggest turning those into data questions if the user hasn't specified one.
+
+## Phase 1: Define the question
+
+Ask via AskUserQuestion:
+
+**"What specific product question do you want to answer with data?**
+
+Good examples:
+- 'What is our funnel conversion from signup to first core action?'
+- 'Why do users drop off after onboarding step 2?'
+- 'What is Day 7 and Day 30 retention?'
+- 'Which features do power users use that casual users don't?'
+- 'Did the new onboarding we shipped 3 weeks ago improve activation?'
+
+Bad examples (too vague):
+- 'How is the product doing?'
+- 'What are our metrics?'"
+
+From the question, identify:
+- **Analysis type:** trend / funnel / retention / path / cohort comparison / feature impact
+- **Time range:** default last 30 days unless question implies otherwise
+- **Key events needed:** list the event names to fetch
+
+## Phase 2: Detect available analytics tier
+
+```bash
+_TIER_POSTHOG=$(nanopm_has_connector posthog)
+_TIER_AMPLITUDE=$(nanopm_has_connector amplitude)
+echo "POSTHOG: $_TIER_POSTHOG | AMPLITUDE: $_TIER_AMPLITUDE"
+```
+
+**Priority:** PostHog MCP first (most capable) → PostHog API → Amplitude API → manual.
+
+If PostHog MCP available: fetch available event definitions first to use correct event names:
+```
+mcp__claude_ai_PostHog__event-definitions-list()
+mcp__claude_ai_PostHog__projects-get()
+```
+
+If neither PostHog nor Amplitude available: go to Tier 4 (manual paste).
+
+## Phase 3: Fetch the data
+
+Run the appropriate queries based on the analysis type. Show progress ("Fetching funnel data...") but do not show raw API responses to the user — only the interpreted output.
+
+**For funnel questions:**
+- Define the 3-5 most logical steps for the funnel
+- If event names are unclear, infer from event definitions or ask one targeted question
+- Fetch conversion rate per step + absolute numbers
+- Identify the single biggest drop-off step
+
+**For retention questions:**
+- Fetch Day 1, Day 7, Day 30 retention by default
+- If a specific event is mentioned, use it as the returning event
+- Compare against industry benchmarks: D1 > 25% good, D7 > 10% good, D30 > 5% good (SaaS baseline)
+
+**For trend questions:**
+- Fetch last 30 days by default, with prior 30-day comparison
+- Calculate % change: positive/negative, significant (>10%) or noise (<5%)
+
+**For path questions:**
+- Fetch paths after a key event (e.g., after "signed_up")
+- Identify the top 3 most common paths and the most common exit points
+
+**For cohort comparison:**
+- Split users by a defining behavior (e.g., completed onboarding vs didn't)
+- Compare retention, activation rate, or feature usage between cohorts
+
+**For feature impact:**
+- Define "before" period (30 days pre-ship) and "after" period (30 days post-ship)
+- Compare the target metric between the two periods
+- Flag confounders if visible (e.g., big traffic spike from a campaign)
+
+## Phase 4: Interpret the data
+
+Do not just dump numbers. Interpret every metric:
+
+**For each data point:**
+- What does this number mean in plain English?
+- Is it good, bad, or unclear? (use benchmarks where available)
+- What does it suggest about user behavior?
+- What follow-up question does it raise?
+
+**The so-what rule:** Every number must be followed by "which means..." or "which suggests...". A number without interpretation is noise.
+
+**Confidence level for each finding:**
+- 🟢 High confidence — large sample (>500 users), clear pattern, consistent over time
+- 🟡 Medium confidence — moderate sample (100–500), some variance
+- 🔴 Low confidence — small sample (<100), noisy, or only 1-2 weeks of data
+
+**Triangulation:** If FEEDBACK.md exists, check for qualitative signal that confirms or contradicts the quantitative findings. A quantitative drop-off confirmed by user interview quotes is a strong signal. A number with no qualitative backing is a hypothesis, not a finding.
+
+## Phase 5: Write DATA.md
+
+Write to `.nanopm/DATA.md` (append if file exists — preserve prior analyses):
+
+```markdown
+---
+
+## Data Analysis — {date}
+
+**Question:** {the specific question answered}
+**Source:** {PostHog | Amplitude | manual}
+**Time range:** {date range}
+
+### Findings
+
+**{Finding 1 title}**
+{Number}: {what it means} — {so what / implication}
+Confidence: {🟢 High | 🟡 Medium | 🔴 Low} — {reason}
+
+**{Finding 2 title}**
+...
+
+### Key insight
+
+{One paragraph. The most important thing the data reveals. Not a list — a narrative.
+What is the data actually saying about user behavior? What does it suggest you should do?}
+
+### Biggest unknown
+
+{The most important question the data raises but cannot answer alone.
+Usually answered by qualitative research — flag it for /pm-interview if relevant.}
+
+### Recommended next
+
+{/pm-audit to fold this into the product assessment |
+/pm-interview to investigate the biggest unknown qualitatively |
+/pm-prd if the problem is validated and sized}
+
+---
+```
+
+## Phase 6: Save context
+
+```bash
+nanopm_context_append "{\"skill\":\"pm-data\",\"outputs\":{\"question\":\"$(head -10 .nanopm/DATA.md | grep 'Question' | cut -d: -f2- | xargs | tr '\"' \"'\" | head -c 100)\",\"source\":\"posthog\",\"next\":\"pm-audit\"}}"
+```
+
+## Completion
+
+Tell the user:
+- DATA.md updated
+- The single most important finding in one sentence
+- The confidence level and what would increase it
+- Whether this data suggests running more interviews (/pm-interview) or moving to planning (/pm-audit)
+
+If the data reveals a clear problem with quantified size: "This is now ready to feed into /pm-audit — the quantitative problem size strengthens the audit's strategic recommendations."
+
+## Telemetry
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.nanopm/analytics/.pending-"$_TEL_SESSION_ID" 2>/dev/null || true
+
+_OUTCOME="success"
+
+if [ -x ~/.nanopm/bin/nanopm-telemetry-log ]; then
+  ~/.nanopm/bin/nanopm-telemetry-log \
+    --skill "pm-data" \
+    --duration "$_TEL_DUR" \
+    --outcome "$_OUTCOME" \
+    --session-id "$_TEL_SESSION_ID" 2>/dev/null || true
+fi
+```
+
+**STATUS: DONE**

--- a/pm-interview/SKILL.md
+++ b/pm-interview/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: pm-interview
+version: 0.2.0
+description: "User interview guide. Prepares a structured interview guide for a specific assumption or discovery question, conducts the session live or imports from Granola, extracts signal, and appends findings to FEEDBACK.md for use by /pm-audit and /pm-user-feedback."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent, WebFetch, mcp__claude_ai_Granola__list_meetings, mcp__claude_ai_Granola__get_meeting_transcript, mcp__claude_ai_Granola__query_granola_meetings
+---
+
+## Preamble (run first)
+
+```bash
+source ~/.nanopm/lib/nanopm.sh 2>/dev/null || \
+  source .nanopm/lib/nanopm.sh 2>/dev/null || \
+  { echo "ERROR: nanopm not installed. Run: curl -fsSL https://raw.githubusercontent.com/nmrtn/nanopm/main/setup | bash"; exit 1; }
+nanopm_preamble
+nanopm_telemetry_pending "pm-interview"
+_FEEDBACK_FILE=".nanopm/FEEDBACK.md"
+_INTERVIEW_FILE=".nanopm/INTERVIEW.md"
+```
+
+## When to run this
+
+Run `/pm-interview` when:
+- You have a specific assumption to validate (from /pm-discovery or /pm-audit)
+- You want to understand why users behave a certain way
+- You're about to write a PRD and need user signal first
+- You want to update FEEDBACK.md with fresh qualitative data
+
+Do NOT use this to pitch your solution. Use it to understand the problem.
+
+## Phase 0: Prior context
+
+```bash
+nanopm_context_read pm-interview
+nanopm_context_all
+```
+
+If prior interview entries found: "Found {N} past interview sessions. This session builds on them."
+
+Also check if DISCOVERY.md exists — if so, read the top assumptions to pre-populate the focus.
+
+```bash
+[ -f ".nanopm/DISCOVERY.md" ] && echo "DISCOVERY_EXISTS" || echo "DISCOVERY_MISSING"
+[ -f ".nanopm/AUDIT.md" ] && echo "AUDIT_EXISTS" || echo "AUDIT_MISSING"
+```
+
+## Phase 1: Set the focus
+
+Ask via AskUserQuestion — ONE question:
+
+**"What specific assumption or question should this interview answer?**
+
+Examples:
+- 'Do PMs at startups feel their current standup process is broken?'
+- 'Why are users dropping off after the onboarding flow?'
+- 'Would someone pay for this before it's built?'
+- 'What's the biggest frustration with [competitor]?'
+
+If you have DISCOVERY.md open, I'll suggest the top-risk assumption."
+
+If DISCOVERY_EXISTS, extract the top assumption from the assumption inventory and suggest it as the default. Let the user confirm or override.
+
+This focus question drives everything — the interview guide, the signal extraction, and how findings map to the roadmap.
+
+## Phase 2: Interviewee profile
+
+Ask via AskUserQuestion:
+
+**"Who is the person you're interviewing?**
+
+- Job title and company size
+- Their relationship to the problem (power user, churned user, prospect, never tried it)
+- How did you find them?
+
+If you don't have someone scheduled yet, I can help you think through who to target."
+
+If the answer is "I don't have anyone yet": output a recruitment script (2-3 sentences for LinkedIn / Slack / cold email) targeting the ideal profile from DISCOVERY.md or AUDIT.md context. Then stop — don't continue the interview guide until they have a subject.
+
+## Phase 3: Build the interview guide
+
+Based on the focus question and interviewee profile, generate a structured interview guide.
+
+**Opening (2 min)**
+- Set context: "I'm trying to understand your experience with [problem area], not sell anything."
+- Ask for permission to take notes.
+- Warm-up: "Tell me a bit about your role and what [relevant activity] looks like in your day."
+
+**Core questions (15-20 min)**
+
+Generate 5-7 open-ended questions following these rules:
+- Start with behavior ("Tell me about the last time you..."), not opinion ("Do you think...")
+- Go from past to present — never hypothetical future ("Would you use...")
+- One question per topic — no compound questions
+- Include at least one "worst experience" and one "workaround" question
+
+Format:
+```
+Q1: [question]
+   → If they give a vague answer: [follow-up probe]
+   → Signal to listen for: [what confirms or refutes the assumption]
+
+Q2: ...
+```
+
+**Closing (3 min)**
+- "Is there anything about [problem area] I didn't ask that you think is important?"
+- "Who else do you think I should talk to?"
+- Thank them.
+
+**Anti-patterns to avoid:**
+- Never ask "Would you use X?" — it produces false positives
+- Never describe your solution before the core questions
+- Never interpret while they're talking — note, then follow up
+
+## Phase 4: Live capture mode
+
+Tell the user:
+
+> "Interview guide ready. When you're done with the session, come back and I'll help you extract the signal.
+>
+> Run `/pm-interview` again and say 'I just finished the interview' to start extraction."
+
+If the user says they've just finished an interview, proceed to Phase 5.
+
+## Phase 5: Signal extraction
+
+**Check Granola first:**
+
+Try `mcp__claude_ai_Granola__query_granola_meetings` with the interviewee name or topic from Phase 2.
+
+If a matching meeting is found:
+- Fetch the full transcript with `mcp__claude_ai_Granola__get_meeting_transcript`
+- Tell the user: "Found a Granola transcript for this session — extracting signal automatically."
+- Use the transcript as the source for Phase 5 extraction. Skip the manual paste question.
+
+If no Granola transcript found: ask via AskUserQuestion:
+
+**"Give me your raw notes from the interview — paste them here, or describe what happened. Don't filter. Include exact quotes if you have them."**
+
+From the raw notes, extract:
+
+**Key findings:**
+- What did they say that surprised you?
+- What confirmed existing assumptions?
+- What refuted them?
+
+**Verbatim quotes** (mark the most powerful one with ⭐):
+> "exact quote" — [context]
+
+**Jobs and pains identified:**
+| Job they're trying to do | Current workaround | Pain level (1-5) | Frequency |
+|--------------------------|-------------------|------------------|-----------|
+
+**Assumption verdict:**
+- Focus assumption: [restate it]
+- Verdict: CONFIRMED / REFUTED / INCONCLUSIVE
+- Evidence: [what they said]
+
+**What to do next:**
+- If CONFIRMED: note it, run more interviews to increase confidence, or proceed to /pm-audit
+- If REFUTED: revisit /pm-discovery — the assumption needs reframing
+- If INCONCLUSIVE: flag which follow-up question would have clarified it
+
+## Phase 6: Write findings
+
+Append to `.nanopm/FEEDBACK.md` (create if missing):
+
+```markdown
+---
+
+## Interview — {date} — {interviewee profile}
+
+**Focus:** {assumption or question being tested}
+
+**Key findings:**
+{bullet list}
+
+**Quotes:**
+{verbatim quotes, best one marked ⭐}
+
+**Jobs & pains:**
+| Job | Workaround | Pain | Frequency |
+|-----|-----------|------|-----------|
+{rows}
+
+**Assumption verdict:** {CONFIRMED / REFUTED / INCONCLUSIVE}
+> {one sentence summary}
+
+**Recommended next:** {/pm-discovery to reframe | /pm-audit | more interviews (N total recommended)}
+
+---
+```
+
+If FEEDBACK.md already exists, append below the existing content — do NOT overwrite.
+
+Also write a session summary to `.nanopm/INTERVIEW.md` (overwrite — this is the latest session only).
+
+## Phase 7: Save context
+
+```bash
+nanopm_context_append "{\"skill\":\"pm-interview\",\"outputs\":{\"focus\":\"$(head -20 .nanopm/INTERVIEW.md | grep 'Focus' | cut -d: -f2- | xargs | tr '\"' \"'\" | head -c 100)\",\"verdict\":\"$(grep 'Assumption verdict' .nanopm/INTERVIEW.md | cut -d: -f2- | xargs | head -c 50)\",\"next\":\"pm-audit\"}}"
+```
+
+## Completion
+
+Tell the user:
+- FEEDBACK.md updated with interview findings
+- The assumption verdict (CONFIRMED / REFUTED / INCONCLUSIVE) and what it means for the roadmap
+- How many interviews are typically needed before signal is reliable (5 is the standard; 3 minimum for a single assumption)
+- Recommended next: `/pm-audit` if signal is sufficient, or schedule another interview if INCONCLUSIVE
+
+## Telemetry
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.nanopm/analytics/.pending-"$_TEL_SESSION_ID" 2>/dev/null || true
+
+_OUTCOME="success"
+
+if [ -x ~/.nanopm/bin/nanopm-telemetry-log ]; then
+  ~/.nanopm/bin/nanopm-telemetry-log \
+    --skill "pm-interview" \
+    --duration "$_TEL_DUR" \
+    --outcome "$_OUTCOME" \
+    --session-id "$_TEL_SESSION_ID" 2>/dev/null || true
+fi
+```
+
+**STATUS: DONE**

--- a/pm-interview/SKILL.md
+++ b/pm-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pm-interview
-version: 0.2.0
-description: "User interview guide. Prepares a structured interview guide for a specific assumption or discovery question, conducts the session live or imports from Granola, extracts signal, and appends findings to FEEDBACK.md for use by /pm-audit and /pm-user-feedback."
+version: 0.3.0
+description: "User interview guide based on Teresa Torres (story-based), Rob Fitzpatrick (Mom Test), Bob Moesta (JTBD Switch), and Cindy Alvarez (Lean Customer Dev). Prepares a hypothesis-driven guide, runs live or imports from Granola, extracts signal into FEEDBACK.md."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent, WebFetch, mcp__claude_ai_Granola__list_meetings, mcp__claude_ai_Granola__get_meeting_transcript, mcp__claude_ai_Granola__query_granola_meetings
 ---
 
@@ -22,10 +22,19 @@ _INTERVIEW_FILE=".nanopm/INTERVIEW.md"
 Run `/pm-interview` when:
 - You have a specific assumption to validate (from /pm-discovery or /pm-audit)
 - You want to understand why users behave a certain way
-- You're about to write a PRD and need user signal first
-- You want to update FEEDBACK.md with fresh qualitative data
+- You're about to write a PRD and need real user signal first
+- You just finished a user call and want to extract the signal
 
-Do NOT use this to pitch your solution. Use it to understand the problem.
+**The goal is never to pitch.** The goal is to collect specific stories from the past that reveal real behavior.
+
+## Frameworks used
+
+This skill draws from four recognized approaches:
+
+- **Rob Fitzpatrick (The Mom Test):** Only ask questions that are honest even if the interviewee wants to please you. Past behavior only, no hypotheticals.
+- **Teresa Torres (Continuous Discovery Habits):** One specific story per interview. Anchor to a real past event, then excavate the timeline.
+- **Bob Moesta (JTBD Switch Interview):** Map the full decision timeline — from first dissatisfaction to current use. Identify the four forces (push, pull, anxiety, inertia).
+- **Cindy Alvarez (Lean Customer Development):** Falsify your critical hypotheses. Know your top 3 questions before the call. End with a forward action.
 
 ## Phase 0: Prior context
 
@@ -34,32 +43,41 @@ nanopm_context_read pm-interview
 nanopm_context_all
 ```
 
-If prior interview entries found: "Found {N} past interview sessions. This session builds on them."
+If prior interview entries found: "Found {N} past sessions. This session builds on them — prior verdicts will inform the guide."
 
-Also check if DISCOVERY.md exists — if so, read the top assumptions to pre-populate the focus.
+Read prior context to understand which assumptions have already been tested and what signal exists.
 
 ```bash
 [ -f ".nanopm/DISCOVERY.md" ] && echo "DISCOVERY_EXISTS" || echo "DISCOVERY_MISSING"
 [ -f ".nanopm/AUDIT.md" ] && echo "AUDIT_EXISTS" || echo "AUDIT_MISSING"
+[ -f ".nanopm/FEEDBACK.md" ] && echo "FEEDBACK_EXISTS" || echo "FEEDBACK_MISSING"
 ```
 
 ## Phase 1: Set the focus
 
-Ask via AskUserQuestion — ONE question:
+Ask via AskUserQuestion:
 
-**"What specific assumption or question should this interview answer?**
+**"What are you trying to learn from this interview?**
 
-Examples:
-- 'Do PMs at startups feel their current standup process is broken?'
-- 'Why are users dropping off after the onboarding flow?'
-- 'Would someone pay for this before it's built?'
-- 'What's the biggest frustration with [competitor]?'
+Be specific — name the assumption or behavior you want to understand.
 
-If you have DISCOVERY.md open, I'll suggest the top-risk assumption."
+Good examples:
+- 'I want to know why PMs at startups feel their standup process is broken'
+- 'I want to understand why users drop off after onboarding step 3'
+- 'I want to know what workaround people use when they can't do X'
 
-If DISCOVERY_EXISTS, extract the top assumption from the assumption inventory and suggest it as the default. Let the user confirm or override.
+Bad examples (too vague):
+- 'What users think of the product'
+- 'General feedback'
 
-This focus question drives everything — the interview guide, the signal extraction, and how findings map to the roadmap.
+If you have DISCOVERY.md or AUDIT.md open, I'll suggest the highest-risk assumption as a default."
+
+If DISCOVERY_EXISTS or AUDIT_EXISTS: extract the top-risk assumption and suggest it. Let the user confirm or override.
+
+From the focus, extract or infer:
+- The **specific behavior** to anchor the story on (e.g., "the last time they chose what to watch")
+- The **critical hypotheses** to falsify (max 3)
+- The **stage** (pre-product/discovery, feature validation, churn/retention investigation, positioning)
 
 ## Phase 2: Interviewee profile
 
@@ -68,58 +86,138 @@ Ask via AskUserQuestion:
 **"Who is the person you're interviewing?**
 
 - Job title and company size
-- Their relationship to the problem (power user, churned user, prospect, never tried it)
-- How did you find them?
+- Their relationship to the problem: current user / churned user / prospect / never tried it
+- How you found them
 
-If you don't have someone scheduled yet, I can help you think through who to target."
+If you don't have someone yet, I can write a recruitment message."
 
-If the answer is "I don't have anyone yet": output a recruitment script (2-3 sentences for LinkedIn / Slack / cold email) targeting the ideal profile from DISCOVERY.md or AUDIT.md context. Then stop — don't continue the interview guide until they have a subject.
+**If no subject yet:** write a 3-sentence recruitment message (LinkedIn or Slack) targeting the ideal profile from DISCOVERY.md/AUDIT.md context. Include: who you're looking for, what you want to talk about (problem, not your solution), and a clear ask (30-min call).
+
+**Interview type detection:** Based on the relationship to the problem, classify the session:
+- **Current user** → use story-based (Torres) + JTBD ongoing use questions
+- **Churned user / switched away** → use JTBD Switch full timeline (Moesta)
+- **Prospect / never tried** → use Lean Customer Dev (Alvarez) + Mom Test
+- **Buyer / decision-maker** → use positioning interview (Dunford framing)
 
 ## Phase 3: Build the interview guide
 
-Based on the focus question and interviewee profile, generate a structured interview guide.
+Generate a complete, ready-to-use interview guide. The guide is a **compass, not a script** (Constable) — questions are ordered by criticality, most important hypotheses first.
 
-**Opening (2 min)**
-- Set context: "I'm trying to understand your experience with [problem area], not sell anything."
-- Ask for permission to take notes.
-- Warm-up: "Tell me a bit about your role and what [relevant activity] looks like in your day."
+---
 
-**Core questions (15-20 min)**
+### Opening (3–5 min)
 
-Generate 5-7 open-ended questions following these rules:
-- Start with behavior ("Tell me about the last time you..."), not opinion ("Do you think...")
-- Go from past to present — never hypothetical future ("Would you use...")
-- One question per topic — no compound questions
-- Include at least one "worst experience" and one "workaround" question
+Set the frame:
+> "Thanks for making time. I'm trying to understand your experience with [problem area] — I'm not here to pitch anything, just to learn. I'll ask you about specific situations you've been in, not hypothetical scenarios. Mind if I take notes?"
+
+Warm-up:
+> "Tell me a bit about your role and what [relevant activity] looks like in a typical week."
+
+---
+
+### Story anchor (Torres method)
+
+Pick ONE behavior most likely to reveal the assumption. Anchor to a real past event:
+
+> "I'd love to start with a specific situation. **Tell me about the last time you [specific behavior].**"
+
+- If they generalize ("I usually...") → redirect: "Let's focus on one specific time — the most recent one you can remember. Walk me through what actually happened."
+- Excavate the timeline with neutral prompts: "What happened first?" / "What happened next?" / "What made you decide to do that?"
+- Never interpret while they're talking. Note, then follow up.
+
+---
+
+### Core questions (15–20 min)
+
+Generate 5–7 questions based on the interview type and focus. Apply these rules for every question:
+
+**Mom Test rules (Fitzpatrick):**
+- ✓ Ask about specific past behavior: "Tell me about the last time..."
+- ✓ Ask what they've tried: "What else have you tried to solve this?"
+- ✓ Ask about implications: "What happens when [problem] occurs?"
+- ✗ Never ask: "Would you use X?" / "Do you think X is a good idea?" / "How much would you pay?"
+- ✗ Never ask hypothetical future questions
+
+**Mandatory questions (always include):**
+1. **Workaround question:** "How are you handling [the problem] right now? Walk me through exactly what you do."
+   → *Reveals your real competition. If the answer is "nothing," probe harder — someone with a real problem always has a workaround.*
+
+2. **Implication question:** "What happens if you don't solve this? What does it cost you — time, money, stress?"
+   → *Separates a real problem from a minor irritant. No real cost = weak signal.*
+
+3. **Alternative question:** "What else have you tried? What did you like or hate about it?"
+   → *Reveals the competitive landscape and pricing anchor.*
+
+**For JTBD Switch sessions (Moesta), follow the 6 stages:**
+1. First Thought: "When did you first realize something needed to change? What triggered that?"
+2. Passive Looking: "At what point did you start casually noticing alternatives?"
+3. Active Looking: "When did you start seriously evaluating options?"
+4. Deciding: "Walk me through the moment you made the decision."
+5. Onboarding: "What was the first thing you did after you started?"
+6. Ongoing Use: "How is your situation different now? What can you do that you couldn't before?"
+
+Map the four forces during the session:
+- **Push** (frustration with current situation): listen for "I was frustrated by...", "It wasn't working because..."
+- **Pull** (attraction to new solution): listen for "I heard that...", "I wanted to be able to..."
+- **Anxiety** (fear of switching): listen for "I was worried that...", "I wasn't sure if..."
+- **Inertia** (attachment to old solution): listen for "I was used to...", "We had already..."
+
+**Probing techniques (NNG funnel):**
+- "Can you tell me more about that?"
+- "What do you mean by [vague word]?" — never let abstract words (easy, fast, better) pass without unpacking
+- "Why does that matter to you?"
+- **Silence** — wait 3–5 seconds before following up. Interviewees fill silence with the most honest answers.
+- "You mentioned X — can we go back to that?"
+- "Faster than what?" / "Better than how?" (Moesta) — contrast reveals meaning
+
+---
+
+### Hypothesis check (Alvarez)
+
+For each of the top 3 critical hypotheses, include one targeted question. Order these by criticality — most important first (Constable: if the call cuts short, you've still tested the most critical hypothesis).
 
 Format:
 ```
-Q1: [question]
-   → If they give a vague answer: [follow-up probe]
-   → Signal to listen for: [what confirms or refutes the assumption]
-
-Q2: ...
+Hypothesis: [belief]
+Question: [specific behavior-based question to test it]
+Confirmation signal: [what answer would confirm it]
+Refutation signal: [what answer would refute it]
 ```
 
-**Closing (3 min)**
-- "Is there anything about [problem area] I didn't ask that you think is important?"
-- "Who else do you think I should talk to?"
-- Thank them.
+---
 
-**Anti-patterns to avoid:**
-- Never ask "Would you use X?" — it produces false positives
-- Never describe your solution before the core questions
-- Never interpret while they're talking — note, then follow up
+### Closing (3–5 min)
+
+> "Is there anything about [problem area] you expected me to ask that I didn't?"
+> "Who else do you think I should talk to? Could you introduce me?"
+> "What would be most useful for me to send you as a follow-up?"
+
+**Forward action** (Alvarez): always end with a specific next step — an intro, a follow-up session, or sharing a prototype later.
+
+---
+
+### Anti-patterns to avoid
+
+| What to avoid | Why |
+|---|---|
+| "Would you use X?" | Produces false positives — people say yes to be polite |
+| Pitching before the core questions | Biases every answer that follows |
+| Interpreting aloud while they talk | Shuts down their train of thought |
+| Asking compound questions | Interviewee answers only the easiest part |
+| Accepting vague answers without probing | "It was frustrating" tells you nothing |
+| Asking about hypothetical futures | Behavior prediction is unreliable |
+
+---
 
 ## Phase 4: Live capture mode
 
 Tell the user:
 
-> "Interview guide ready. When you're done with the session, come back and I'll help you extract the signal.
+> "Guide ready. Recommended duration: 30–45 min. The questions are ordered by importance — if the call runs short, you've still covered the most critical hypothesis.
 >
-> Run `/pm-interview` again and say 'I just finished the interview' to start extraction."
+> When you're done, come back and say 'I just finished the interview' — I'll extract the signal. If you recorded in Granola, I'll pull the transcript automatically."
 
-If the user says they've just finished an interview, proceed to Phase 5.
+If the user says they've just finished: proceed to Phase 5.
 
 ## Phase 5: Signal extraction
 
@@ -128,37 +226,50 @@ If the user says they've just finished an interview, proceed to Phase 5.
 Try `mcp__claude_ai_Granola__query_granola_meetings` with the interviewee name or topic from Phase 2.
 
 If a matching meeting is found:
-- Fetch the full transcript with `mcp__claude_ai_Granola__get_meeting_transcript`
-- Tell the user: "Found a Granola transcript for this session — extracting signal automatically."
-- Use the transcript as the source for Phase 5 extraction. Skip the manual paste question.
+- Fetch full transcript with `mcp__claude_ai_Granola__get_meeting_transcript`
+- Tell the user: "Found a Granola transcript — extracting signal automatically."
+- Use the transcript as source. Skip the manual paste question.
 
-If no Granola transcript found: ask via AskUserQuestion:
+If no Granola transcript: ask via AskUserQuestion:
 
-**"Give me your raw notes from the interview — paste them here, or describe what happened. Don't filter. Include exact quotes if you have them."**
+**"Paste your raw notes — don't filter, don't clean up. Exact quotes are the most valuable thing."**
 
-From the raw notes, extract:
+---
+
+From the raw notes or transcript, extract:
 
 **Key findings:**
-- What did they say that surprised you?
 - What confirmed existing assumptions?
-- What refuted them?
+- What surprised you or contradicted assumptions?
+- What was implied but never said directly?
 
-**Verbatim quotes** (mark the most powerful one with ⭐):
+**Verbatim quotes** (mark the strongest one ⭐):
 > "exact quote" — [context]
+*Pick quotes that reveal emotion, workaround behavior, or a real cost. Paraphrases have no value here.*
 
-**Jobs and pains identified:**
-| Job they're trying to do | Current workaround | Pain level (1-5) | Frequency |
-|--------------------------|-------------------|------------------|-----------|
+**Four forces map (JTBD):**
+| Force | Evidence from this session |
+|-------|--------------------------|
+| Push (why they wanted to change) | |
+| Pull (what attracted them) | |
+| Anxiety (what held them back) | |
+| Inertia (what they were attached to) | |
 
-**Assumption verdict:**
-- Focus assumption: [restate it]
+**Jobs identified:**
+| Functional job | Emotional job | Current workaround | Pain level (1–5) | Frequency |
+|---------------|--------------|-------------------|-----------------|-----------|
+
+**Hypothesis verdicts:**
+For each hypothesis tested:
+- Hypothesis: [restate it]
 - Verdict: CONFIRMED / REFUTED / INCONCLUSIVE
-- Evidence: [what they said]
+- Evidence: [what they said or did]
 
-**What to do next:**
-- If CONFIRMED: note it, run more interviews to increase confidence, or proceed to /pm-audit
-- If REFUTED: revisit /pm-discovery — the assumption needs reframing
-- If INCONCLUSIVE: flag which follow-up question would have clarified it
+**Signal reliability:**
+- 1–2 interviews: directional only, don't act yet
+- 3 interviews: minimum for a single assumption
+- 5 interviews: standard threshold (Teresa Torres / Nielsen Norman)
+- 8–12 interviews: sufficient for a full JTBD map (Moesta)
 
 ## Phase 6: Write findings
 
@@ -169,44 +280,55 @@ Append to `.nanopm/FEEDBACK.md` (create if missing):
 
 ## Interview — {date} — {interviewee profile}
 
-**Focus:** {assumption or question being tested}
+**Focus:** {assumption or question tested}
+**Session type:** {story-based | JTBD switch | lean discovery | positioning}
 
 **Key findings:**
-{bullet list}
+{bullet list — specific and concrete}
 
-**Quotes:**
-{verbatim quotes, best one marked ⭐}
+**Best quote** ⭐:
+> "{exact verbatim quote}" — {context}
 
-**Jobs & pains:**
-| Job | Workaround | Pain | Frequency |
-|-----|-----------|------|-----------|
-{rows}
+**Other quotes:**
+> "{quote}" — {context}
 
-**Assumption verdict:** {CONFIRMED / REFUTED / INCONCLUSIVE}
-> {one sentence summary}
+**Four forces:**
+| Force | Evidence |
+|-------|---------|
+| Push | {what frustrated them about the status quo} |
+| Pull | {what attracted them toward a solution} |
+| Anxiety | {what made them hesitant} |
+| Inertia | {what they were reluctant to leave behind} |
 
-**Recommended next:** {/pm-discovery to reframe | /pm-audit | more interviews (N total recommended)}
+**Jobs identified:**
+| Functional job | Emotional job | Workaround | Pain | Frequency |
+|---|---|---|---|---|
+
+**Hypothesis verdicts:**
+- {hypothesis}: {CONFIRMED / REFUTED / INCONCLUSIVE} — {evidence}
+
+**Recommended next:**
+{/pm-discovery to reframe | /pm-audit | more interviews (N total so far, {5 - N} more recommended) | /pm-prd if signal is sufficient}
 
 ---
 ```
 
-If FEEDBACK.md already exists, append below the existing content — do NOT overwrite.
-
-Also write a session summary to `.nanopm/INTERVIEW.md` (overwrite — this is the latest session only).
+Write session summary to `.nanopm/INTERVIEW.md` (overwrite — latest session only).
 
 ## Phase 7: Save context
 
 ```bash
-nanopm_context_append "{\"skill\":\"pm-interview\",\"outputs\":{\"focus\":\"$(head -20 .nanopm/INTERVIEW.md | grep 'Focus' | cut -d: -f2- | xargs | tr '\"' \"'\" | head -c 100)\",\"verdict\":\"$(grep 'Assumption verdict' .nanopm/INTERVIEW.md | cut -d: -f2- | xargs | head -c 50)\",\"next\":\"pm-audit\"}}"
+nanopm_context_append "{\"skill\":\"pm-interview\",\"outputs\":{\"focus\":\"$(head -20 .nanopm/INTERVIEW.md | grep 'Focus' | cut -d: -f2- | xargs | tr '\"' \"'\" | head -c 100)\",\"verdict\":\"$(grep 'Hypothesis verdicts' .nanopm/INTERVIEW.md | cut -d: -f2- | xargs | head -c 50)\",\"next\":\"pm-audit\"}}"
 ```
 
 ## Completion
 
 Tell the user:
-- FEEDBACK.md updated with interview findings
-- The assumption verdict (CONFIRMED / REFUTED / INCONCLUSIVE) and what it means for the roadmap
-- How many interviews are typically needed before signal is reliable (5 is the standard; 3 minimum for a single assumption)
-- Recommended next: `/pm-audit` if signal is sufficient, or schedule another interview if INCONCLUSIVE
+- FEEDBACK.md updated
+- Hypothesis verdicts summary (CONFIRMED / REFUTED / INCONCLUSIVE per hypothesis)
+- Current signal reliability level (N interviews done, how many more needed)
+- If any hypothesis was REFUTED: "This is valuable — a refuted assumption before you built saves weeks. Run /pm-discovery to reframe."
+- Recommended next skill
 
 ## Telemetry
 

--- a/pm-prd/SKILL.md
+++ b/pm-prd/SKILL.md
@@ -50,6 +50,17 @@ Store the feature name as `_FEATURE`.
 
 ## Phase 2: User research pull
 
+Check for DATA.md — quantitative analytics from /pm-data:
+
+```bash
+[ -f ".nanopm/DATA.md" ] && echo "DATA_EXISTS" || echo "DATA_MISSING"
+```
+
+**If DATA_EXISTS:** read `.nanopm/DATA.md`. Find findings relevant to `_FEATURE`:
+- Funnel drop-off rates → use to quantify the problem size in the Problem Statement
+- Retention or usage metrics → use as baseline targets in Success Criteria
+- Cite only 🟢 high-confidence metrics — don't use 🔴 low-confidence numbers as facts in a PRD
+
 Check for FEEDBACK.md first — it's the pre-synthesized source that already aggregates Dovetail, Productboard, and other sources:
 
 ```bash
@@ -182,7 +193,9 @@ Status: DRAFT
 Include: who experiences it, how often, what they do today instead (the workaround), and the cost of the workaround.
 2-4 sentences.}
 
-{If Dovetail data was available: include 1-2 verbatim user quotes here.}
+{If DATA.md had relevant 🟢 metrics: include one quantified fact here — e.g., "X% of users drop off at step N" or "only Y% return after day 7". One number, with source: "(DATA.md)".}
+
+{If FEEDBACK.md had relevant quotes: include 1-2 verbatim user quotes here.}
 
 ---
 

--- a/pm-standup/SKILL.md
+++ b/pm-standup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pm-standup
-version: 0.2.0
-description: "Daily standup briefing. Pulls what happened since yesterday from git, Linear, Google Calendar, and Granola. Surfaces today's meetings, priorities, blockers, and anything that drifted. Takes under 60 seconds to run."
+version: 0.3.0
+description: "Daily standup briefing. Pulls commits from all your active GitHub repos, Linear, Google Calendar, and Granola. Works from a standalone Product OS folder — no need to be inside a codebase. Surfaces today's meetings, cross-repo activity, priorities, and drift."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent, mcp__claude_ai_Google_Calendar__gcal_list_events, mcp__claude_ai_Google_Calendar__gcal_list_calendars, mcp__claude_ai_Granola__list_meetings, mcp__claude_ai_Granola__query_granola_meetings
 ---
 
@@ -29,11 +29,36 @@ This skill never asks questions. It reads context, generates the briefing, done.
 
 ## Phase 1: Gather yesterday's activity
 
-**Git activity (last 24h):**
+**GitHub — multi-repo commits (last 24h):**
+
+```bash
+_TIER_GITHUB=$(nanopm_has_connector github)
+echo "GITHUB_TIER: $_TIER_GITHUB"
+```
+
+If GITHUB tier is MCP or API:
+- Fetch all commits by the authenticated user across all repos in the last 24h
+- Use GitHub API: `GET /search/commits?q=author:{username}+committer-date:>{yesterday_iso}&sort=committer-date`
+- For each commit extract: repo name, commit message, timestamp
+- Group by repo — show repo name as prefix: `[repo-name] commit message`
+- Limit to 15 commits total, most recent first
+
+If GITHUB not available: fall back to local git:
 ```bash
 git log --since="24 hours ago" --oneline --no-merges 2>/dev/null | head -10 || echo "NO_GIT"
-git diff --stat HEAD~1 HEAD 2>/dev/null | tail -5 || echo "NO_DIFF"
 ```
+Note in output: "(local repo only — connect GitHub for multi-repo view)"
+
+**First-run repo list:**
+On first run, store the list of active repos found via GitHub API:
+```bash
+nanopm_config_get "github_active_repos"
+```
+If empty: fetch repos with pushes in the last 30 days, store as comma-separated list:
+```bash
+nanopm_config_set "github_active_repos" "{repo1},{repo2},..."
+```
+This speeds up subsequent runs — only query known active repos instead of all repos.
 
 **Linear (if available):**
 ```bash
@@ -54,7 +79,7 @@ If LINEAR not available: read `.nanopm/ROADMAP.md` and check for any manually up
 [ -f ".nanopm/AUDIT.md" ] && echo "AUDIT_EXISTS" || echo "AUDIT_MISSING"
 ```
 
-If ROADMAP_EXISTS: scan for items marked as "this week" or current sprint. Check which have no recent commits.
+If ROADMAP_EXISTS: scan for items marked as "this week" or current sprint. Cross-reference with GitHub commits — flag items with no recent commits across any repo.
 
 **Granola — recent meetings (last 48h):**
 
@@ -92,7 +117,8 @@ Output the standup briefing — concise, scannable, no fluff:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 YESTERDAY
-  ✓ {what was completed — from git commits or Linear Done}
+  ✓ [{repo}] {commit message}
+  ✓ [{repo}] {commit message}
   ✓ {if nothing shipped: "No commits in the last 24h"}
   {if Granola had a user meeting: "📋 User call with {name} — run /pm-interview to extract signal"}
 

--- a/pm-standup/SKILL.md
+++ b/pm-standup/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: pm-standup
+version: 0.2.0
+description: "Daily standup briefing. Pulls what happened since yesterday from git, Linear, Google Calendar, and Granola. Surfaces today's meetings, priorities, blockers, and anything that drifted. Takes under 60 seconds to run."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent, mcp__claude_ai_Google_Calendar__gcal_list_events, mcp__claude_ai_Google_Calendar__gcal_list_calendars, mcp__claude_ai_Granola__list_meetings, mcp__claude_ai_Granola__query_granola_meetings
+---
+
+## Preamble (run first)
+
+```bash
+source ~/.nanopm/lib/nanopm.sh 2>/dev/null || \
+  source .nanopm/lib/nanopm.sh 2>/dev/null || \
+  { echo "ERROR: nanopm not installed. Run: curl -fsSL https://raw.githubusercontent.com/nmrtn/nanopm/main/setup | bash"; exit 1; }
+nanopm_preamble
+nanopm_telemetry_pending "pm-standup"
+_STANDUP_FILE=".nanopm/STANDUP.md"
+```
+
+## When to run this
+
+Run `/pm-standup` at the start of your workday to:
+- Know what you shipped or moved yesterday
+- See today's meetings at a glance
+- Set your top 1-3 priorities for today
+- Surface any blockers before they cost you time
+- Stay aligned with the roadmap without opening 4 tools
+
+This skill never asks questions. It reads context, generates the briefing, done.
+
+## Phase 1: Gather yesterday's activity
+
+**Git activity (last 24h):**
+```bash
+git log --since="24 hours ago" --oneline --no-merges 2>/dev/null | head -10 || echo "NO_GIT"
+git diff --stat HEAD~1 HEAD 2>/dev/null | tail -5 || echo "NO_DIFF"
+```
+
+**Linear (if available):**
+```bash
+_TIER_LINEAR=$(nanopm_has_connector linear)
+echo "LINEAR_TIER: $_TIER_LINEAR"
+```
+
+If LINEAR tier is MCP or API:
+- Fetch issues moved to Done in the last 24h
+- Fetch issues currently In Progress
+- Fetch any issues marked Blocked or flagged
+
+If LINEAR not available: read `.nanopm/ROADMAP.md` and check for any manually updated status.
+
+**Roadmap drift check:**
+```bash
+[ -f ".nanopm/ROADMAP.md" ] && echo "ROADMAP_EXISTS" || echo "ROADMAP_MISSING"
+[ -f ".nanopm/AUDIT.md" ] && echo "AUDIT_EXISTS" || echo "AUDIT_MISSING"
+```
+
+If ROADMAP_EXISTS: scan for items marked as "this week" or current sprint. Check which have no recent commits.
+
+**Granola — recent meetings (last 48h):**
+
+Try `mcp__claude_ai_Granola__list_meetings` with limit: 5.
+
+If available: extract meetings from the last 48h. For each:
+- Title, date, participants
+- Flag any meeting titled with "user", "customer", "interview", "discovery" → note as "📋 user signal available — run /pm-interview to extract"
+
+If Granola not available: skip silently.
+
+## Phase 2: Fetch today's meetings
+
+Try `mcp__claude_ai_Google_Calendar__gcal_list_events` with:
+- calendar_id: "primary"
+- time_min: today 00:00:00
+- time_max: today 23:59:59
+
+If available, for each event extract:
+- Start time, title, duration, attendees count
+- Classify: internal sync | external call | user interview | solo block
+
+**Prep flag logic:**
+If an event title contains a feature name or product area AND there are no git commits touching that area in the last 48h → flag as "⚠ no recent progress on this topic"
+
+If Google Calendar not available: skip the MEETINGS section silently.
+
+## Phase 3: Generate the briefing
+
+Output the standup briefing — concise, scannable, no fluff:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ STANDUP — {Day, Date}  ·  {project slug}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+YESTERDAY
+  ✓ {what was completed — from git commits or Linear Done}
+  ✓ {if nothing shipped: "No commits in the last 24h"}
+  {if Granola had a user meeting: "📋 User call with {name} — run /pm-interview to extract signal"}
+
+TODAY'S MEETINGS
+  {HH:MM} → {event title} ({duration}) {⚠ no recent commits on this topic — if flagged}
+  {if no calendar connected: omit this section entirely}
+
+PRIORITIES
+  → {priority 1 — inferred from roadmap + in-progress items}
+  → {priority 2}
+  → {priority 3 if relevant}
+
+BLOCKERS
+  ⚠ {any blocked Linear issues, or "None"}
+
+DRIFT
+  {if something was planned this week but has no commits: flag it here}
+  {if nothing drifted: "On track"}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Rules for PRIORITIES:**
+- Infer from: in-progress Linear issues → roadmap current sprint items → AUDIT.md biggest gap
+- Weight toward items with meetings today (if you have a review at 14:00, that's probably a priority)
+- Never list more than 3
+- If the roadmap is stale (>20 commits old), flag it: "⚠ ROADMAP.md is {N} commits old — consider /pm-roadmap"
+
+**Rules for DRIFT:**
+- A roadmap item drifted if: it was due this week, has no commits in 48h, and is not marked Done
+- Don't flag items that are explicitly blocked — those appear under BLOCKERS
+
+**Rules for TODAY'S MEETINGS:**
+- Show time + title + duration only — no attendee list (too noisy)
+- Flag prep gaps (no recent commits on the meeting topic) with ⚠
+- If a meeting looks like a user interview (title keywords: user, customer, interview, call, discovery) → append "📋 run /pm-interview after"
+- If no meetings today: show "No meetings today"
+
+## Phase 4: Save and write
+
+Write the briefing to `.nanopm/STANDUP.md` (overwrite — always the latest).
+
+```bash
+nanopm_context_append "{\"skill\":\"pm-standup\",\"outputs\":{\"date\":\"$(date +%Y-%m-%d)\",\"drift\":\"$(grep -c 'DRIFT' .nanopm/STANDUP.md 2>/dev/null || echo 0)\"}}"
+```
+
+Do NOT ask the user anything. Do NOT wait for input. Generate and display the briefing immediately.
+
+## Telemetry
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.nanopm/analytics/.pending-"$_TEL_SESSION_ID" 2>/dev/null || true
+
+_OUTCOME="success"
+
+if [ -x ~/.nanopm/bin/nanopm-telemetry-log ]; then
+  ~/.nanopm/bin/nanopm-telemetry-log \
+    --skill "pm-standup" \
+    --duration "$_TEL_DUR" \
+    --outcome "$_OUTCOME" \
+    --session-id "$_TEL_SESSION_ID" 2>/dev/null || true
+fi
+```
+
+**STATUS: DONE**

--- a/pm-weekly-update/SKILL.md
+++ b/pm-weekly-update/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: pm-weekly-update
+version: 0.1.0
+description: "Weekly stakeholder update. Drafts a clear, honest status email for your manager, CEO, investors, or team. Reads what shipped, what slipped, and what changed strategically. Adapts tone to the audience."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent
+---
+
+## Preamble (run first)
+
+```bash
+source ~/.nanopm/lib/nanopm.sh 2>/dev/null || \
+  source .nanopm/lib/nanopm.sh 2>/dev/null || \
+  { echo "ERROR: nanopm not installed. Run: curl -fsSL https://raw.githubusercontent.com/nmrtn/nanopm/main/setup | bash"; exit 1; }
+nanopm_preamble
+nanopm_telemetry_pending "pm-weekly-update"
+_UPDATE_FILE=".nanopm/WEEKLY_UPDATE.md"
+```
+
+## When to run this
+
+Run `/pm-weekly-update` at the end of your work week to:
+- Draft a stakeholder update without starting from a blank page
+- Stay honest about slippage without burying it
+- Keep your audience aligned on direction, not just activity
+- Build a record of weekly progress (appended to history)
+
+## Phase 0: Prior context
+
+```bash
+nanopm_context_read pm-weekly-update
+nanopm_context_all
+```
+
+Check for previous weekly updates to maintain continuity of tone and ongoing commitments:
+```bash
+ls .nanopm/weekly-updates/ 2>/dev/null | sort | tail -3 || echo "NO_PRIOR_UPDATES"
+```
+
+## Phase 1: Identify the audience
+
+Ask via AskUserQuestion — ONE question:
+
+**"Who is this update for?**
+
+A) My manager / skip-level
+B) CEO or executive team
+C) Investors / board
+D) My dev team
+E) Cross-functional stakeholders (design, marketing, ops)
+
+You can also just describe them in one line."
+
+Each audience gets a different tone and level of detail:
+- **Manager**: tactical, blockers front and center, decisions needed flagged
+- **CEO/exec**: strategic signal only, no implementation detail, status in one word
+- **Investors**: momentum, metrics, risks, no jargon
+- **Dev team**: what shipped, what's next, decisions that affect them
+- **Cross-functional**: what you're building and why it matters to them specifically
+
+## Phase 2: Gather the week's data
+
+**Git activity (last 7 days):**
+```bash
+git log --since="7 days ago" --oneline --no-merges 2>/dev/null | head -20 || echo "NO_GIT"
+```
+
+**Linear (if available):**
+```bash
+_TIER_LINEAR=$(nanopm_has_connector linear)
+echo "LINEAR_TIER: $_TIER_LINEAR"
+```
+
+If LINEAR available:
+- Issues completed this week
+- Issues in progress
+- Issues that slipped from this week's plan
+- Any new issues added mid-week (scope creep signal)
+
+**Roadmap and objectives:**
+```bash
+[ -f ".nanopm/ROADMAP.md" ] && cat .nanopm/ROADMAP.md || echo "NO_ROADMAP"
+[ -f ".nanopm/OBJECTIVES.md" ] && cat .nanopm/OBJECTIVES.md || echo "NO_OBJECTIVES"
+[ -f ".nanopm/AUDIT.md" ] && head -40 .nanopm/AUDIT.md || echo "NO_AUDIT"
+```
+
+**Prior week's commitments:**
+If a previous update exists, extract any "next week I will..." commitments and check which were honored.
+
+## Phase 3: Assess the week honestly
+
+Before drafting, make an honest assessment:
+
+**Status:** 🟢 On track | 🟡 At risk | 🔴 Blocked / behind
+
+**What shipped:** (list, not spin)
+
+**What slipped and why:** (be direct — one sentence per item)
+- "X slipped because Y" not "X is still in progress"
+
+**Strategic signal:** Did anything change this week that affects direction?
+- New user feedback that challenges assumptions
+- A competitor move worth noting
+- A technical constraint that changes scope
+
+**Commitments honored/missed from last week:** (if prior update exists)
+
+## Phase 4: Draft the update
+
+Write the update adapted to the audience from Phase 1.
+
+**Template — Manager / exec:**
+```
+Subject: PM Update — Week of {date}
+
+Status: {🟢 On track | 🟡 At risk | 🔴 Behind}
+
+SHIPPED
+- {item} — {one-line impact}
+- {item}
+
+SLIPPED
+- {item} — {reason, one sentence}
+
+NEXT WEEK
+- {commitment 1}
+- {commitment 2}
+
+NEEDS YOUR INPUT
+- {decision or unblock needed, if any — otherwise omit this section}
+
+STRATEGIC NOTE
+{One paragraph max. Only if something changed worth flagging — new signal, risk, pivot consideration. Omit if nothing material changed.}
+```
+
+**Template — Investors / board:**
+```
+Subject: Weekly Signal — {project} — {date}
+
+ONE LINE: {what moved this week in one sentence}
+
+MOMENTUM
+- {shipped item with measurable impact if available}
+- {traction signal: usage, signups, conversations, revenue}
+
+RISKS
+- {honest risk, one line}
+
+NEXT MILESTONE
+{what you're working toward and when}
+```
+
+**Template — Dev team:**
+```
+## Week of {date}
+
+**Shipped:** {list}
+**In progress:** {list}
+**Blocked:** {list — include who can unblock}
+**Next week's focus:** {top priority}
+**Decisions made:** {any product decisions that affect implementation}
+```
+
+**Rules for all audiences:**
+- Lead with status, not activity
+- Slippage goes in the update — never omit it or bury it
+- One strategic note max — this is an update, not a strategy doc
+- If "needs your input" is empty, omit the section entirely
+- Never use "we're making great progress" without a concrete data point
+
+## Phase 5: Save the update
+
+Write to `.nanopm/WEEKLY_UPDATE.md` (latest draft — overwrite).
+
+Also append to weekly history:
+```bash
+mkdir -p .nanopm/weekly-updates
+cp .nanopm/WEEKLY_UPDATE.md ".nanopm/weekly-updates/$(date +%Y-%m-%d).md" 2>/dev/null || true
+```
+
+```bash
+nanopm_context_append "{\"skill\":\"pm-weekly-update\",\"outputs\":{\"date\":\"$(date +%Y-%m-%d)\",\"audience\":\"stakeholders\",\"status\":\"drafted\"}}"
+```
+
+## Completion
+
+Tell the user:
+- Draft written to `.nanopm/WEEKLY_UPDATE.md`
+- Remind them to check the "NEEDS YOUR INPUT" section before sending — that's the most actionable part
+- If anything slipped: "The slippage is in the update. Don't soften it — your stakeholders will respect the honesty more than the spin."
+
+## Telemetry
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.nanopm/analytics/.pending-"$_TEL_SESSION_ID" 2>/dev/null || true
+
+_OUTCOME="success"
+
+if [ -x ~/.nanopm/bin/nanopm-telemetry-log ]; then
+  ~/.nanopm/bin/nanopm-telemetry-log \
+    --skill "pm-weekly-update" \
+    --duration "$_TEL_DUR" \
+    --outcome "$_OUTCOME" \
+    --session-id "$_TEL_SESSION_ID" 2>/dev/null || true
+fi
+```
+
+**STATUS: DONE**


### PR DESCRIPTION
## What this adds

nanopm's pipeline is entirely qualitative. This PR adds the missing quantitative layer: a dedicated skill to answer product questions with data, integrated into the existing `pm-audit` and `pm-prd` pipeline.

> **Note:** This PR includes the commits from #6. It's cleanest to review after #6 is merged — only the last 2 commits are new here.

---

### New skill: `/pm-data`

Answer a specific product question with data. Enforces one question per run — vague questions produce useless output.

Supported analysis types:
- **Funnel** — conversion rate per step, biggest drop-off identification
- **Trend** — time series with % change vs prior period
- **Retention** — Day 1 / Day 7 / Day 30 with SaaS benchmarks
- **Paths** — most common user flows after a key event
- **Cohort comparison** — behavior diff between two user segments
- **Feature impact** — before/after metric comparison around a ship date

Every finding includes a confidence level 🟢🟡🔴 and a plain-English "so what". No raw number dumps.

Output: `.nanopm/DATA.md` (append — preserves history across runs).

### New connectors

| Connector | Tier 1 (MCP) | Tier 2 (API) |
|-----------|-------------|-------------|
| `posthog` | `mcp__claude_ai_PostHog__*` | `POSTHOG_API_KEY` + `POSTHOG_PROJECT_ID` |
| `amplitude` | — | `AMPLITUDE_API_KEY` + `AMPLITUDE_SECRET_KEY` |

Both degrade to manual paste if unavailable.

---

### Pipeline integration

DATA.md is now a first-class input alongside FEEDBACK.md.

**`/pm-audit` changes (minimal, surgical):**
- Phase 2: reads DATA.md, extracts 🟢 high-confidence metrics and flagged unknowns
- Phase 4: cross-references quanti vs quali — contradictions between DATA.md and FEEDBACK.md are flagged explicitly as the most valuable audit findings
- New Section 5 in AUDIT.md: "What The Data Says" — omitted entirely if no DATA.md exists

**`/pm-prd` changes (minimal, surgical):**
- Phase 2: reads DATA.md for metrics relevant to the feature being specced
- Problem Statement template: slot for one quantified fact from DATA.md
- Success Criteria: baselines can be derived from DATA.md metrics
- Only 🟢 high-confidence findings are cited — low-confidence data is never used as fact in a PRD

---

### Quanti / quali triangulation

If FEEDBACK.md exists, `/pm-data` checks for qualitative signal that confirms or contradicts the numbers. A funnel drop-off confirmed by interview quotes → strong signal. A number with no qualitative backing → flagged as hypothesis.

---

### Design principles

- **One question per run** — enforces specificity, prevents dashboard-dumping
- **Confidence levels on every finding** — separates facts from hypotheses
- **Interpretation over raw data** — every number requires a "which means..."
- **Minimal changes to existing skills** — pm-audit and pm-prd edits are additive only, no behavior changed when DATA.md is absent