### PR TITLE
fix(pm-run): option B no longer halts after audit

### DIFF
--- a/pm-run/SKILL.md
+++ b/pm-run/SKILL.md
@@ -121,8 +121,6 @@ Complete all phases of pm-audit through **Phase 7: Save context**.
 
 After pm-audit completes: "✅ Audit complete. Moving to objectives..."
 
-If user chose B: stop here. Output: "Pipeline stopped after audit. Run /pm-objectives to continue."
-
 ## Phase 4: Run pm-objectives inline
 
 Read and follow `$(nanopm_skill_path pm-objectives)` inline, skipping:


### PR DESCRIPTION
## What

`/pm-run` option **B** ("Skip feedback — audit → PRD only") was halting after the audit instead of continuing to the PRD.

Phase 1 defines B as `audit → PRD only` and the option-B handler says it runs Phases 3–7. But Phase 3 still carried a stale line — `If user chose B: stop here. Pipeline stopped after audit.` — left over from an older option scheme where B meant *audit-only*. So choosing B stopped one step in.

This removes the contradicting line. One-line change.

## Provenance

Found while reviewing #17 (pm-personas), which edited the option-B branch just above this stale line without reconciling it. Pre-existing, but #17 made the contradiction sharper.

## Test

`bash test/skill-syntax.sh` → 64 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)