### PR TITLE
feat(memory): company tier — shared mission/business/org across a company's repos

### DIFF
--- a/lib/nanopm.sh
+++ b/lib/nanopm.sh
@@ -707,6 +707,41 @@ PY
   echo "--- END COMPANY BRIEF ---"
 }
 
+nanopm_company_list() {
+  # Existing companies on this machine (one per line), for the "which company?"
+  # prompt. Empty if none yet.
+  local d="$HOME/.nanopm/companies"
+  [ -d "$d" ] || return 0
+  ls -1 "$d" 2>/dev/null
+}
+
+nanopm_company_link() {
+  # Link this repo to a company and share its company-level docs across every
+  # repo of that company, WITHOUT moving anything out of the familiar .nanopm/:
+  # the docs live once in ~/.nanopm/companies/<slug>/ and are symlinked into
+  # .nanopm/, so skills, the brief, and the viewer all keep reading .nanopm/.
+  # Idempotent. Migrates any pre-existing real copy up before linking.
+  local name="$1" dir slug doc link target
+  [ -n "$name" ] || { echo "nanopm: company name required" >&2; return 1; }
+  nanopm_company_set "$name" || return 1
+  dir=$(nanopm_company_dir) ; slug=$(nanopm_company_slug "$name")
+  mkdir -p "$dir" .nanopm
+  # Literal list (not an unquoted var) so word-splitting works in bash AND zsh.
+  for doc in VISION-MISSION BUSINESS-MODEL ORG; do
+    link=".nanopm/$doc.md" ; target="$dir/$doc.md"
+    if [ -f "$link" ] && [ ! -L "$link" ]; then
+      # A real per-repo copy exists. Migrate it up unless the company already
+      # has one (then keep the company's and back up the local copy).
+      if [ -e "$target" ]; then mv "$link" "$link.local-backup"; else mv "$link" "$target"; fi
+    fi
+    ln -sf "$target" "$link"   # target may not exist yet; skills write through the link
+  done
+  echo "COMPANY_LINKED: $name"
+  echo "  Mission, business model & org for '$name' are now shared across all your"
+  echo "  '$name' repos — stored once in ~/.nanopm/companies/$slug/, linked into this"
+  echo "  repo's .nanopm/. Commit .nanopm-company so other repos/teammates inherit it."
+}
+
 # ── Define-phase mode + retrieval (v0.11.0+) ─────────────────────────────────
 #
 # The five Define skills (vision-mission, business-model, org, product,

--- a/lib/nanopm.sh
+++ b/lib/nanopm.sh
@@ -721,7 +721,7 @@ nanopm_company_link() {
   # the docs live once in ~/.nanopm/companies/<slug>/ and are symlinked into
   # .nanopm/, so skills, the brief, and the viewer all keep reading .nanopm/.
   # Idempotent. Migrates any pre-existing real copy up before linking.
-  local name="$1" dir slug doc link target
+  local name="$1" dir slug doc link target migrated=""
   [ -n "$name" ] || { echo "nanopm: company name required" >&2; return 1; }
   nanopm_company_set "$name" || return 1
   dir=$(nanopm_company_dir) ; slug=$(nanopm_company_slug "$name")
@@ -732,11 +732,12 @@ nanopm_company_link() {
     if [ -f "$link" ] && [ ! -L "$link" ]; then
       # A real per-repo copy exists. Migrate it up unless the company already
       # has one (then keep the company's and back up the local copy).
-      if [ -e "$target" ]; then mv "$link" "$link.local-backup"; else mv "$link" "$target"; fi
+      if [ -e "$target" ]; then mv "$link" "$link.local-backup"; else mv "$link" "$target"; migrated="$migrated $doc"; fi
     fi
     ln -sf "$target" "$link"   # target may not exist yet; skills write through the link
   done
   echo "COMPANY_LINKED: $name"
+  [ -n "$migrated" ] && echo "  Moved your existing$migrated up into the shared company folder."
   echo "  Mission, business model & org for '$name' are now shared across all your"
   echo "  '$name' repos — stored once in ~/.nanopm/companies/$slug/, linked into this"
   echo "  repo's .nanopm/. Commit .nanopm-company so other repos/teammates inherit it."

--- a/pm-business-model/SKILL.md
+++ b/pm-business-model/SKILL.md
@@ -53,6 +53,34 @@ nanopm_context_all
 
 If a prior pm-business-model entry exists: "Prior business model from {ts}. This run will refine it, not start over."
 
+## Phase 0.5: Link this repo to a company
+
+The company-level docs (mission, business model, org) are **shared** across every
+repo of the same company — you write them once. If this repo isn't linked to a
+company yet, link it now, *before* mode detection (linking is what makes a sibling
+repo's existing company docs visible here).
+
+```bash
+_COMPANY=$(nanopm_company_get)
+echo "COMPANY: ${_COMPANY:-NONE}"
+nanopm_company_list | sed 's/^/  existing-company: /'
+```
+
+**If COMPANY is NONE**, ask via **one** `AskUserQuestion` (header `Company`, ≤12 chars):
+"Which company is this repo for? Its mission, business model & org are shared across
+all repos of that company." Options = each company from `nanopm_company_list`, plus
+**"New company…"** (free-text name). Then link it:
+
+```bash
+nanopm_company_link "<chosen or newly-entered company name>"
+```
+
+Show the `COMPANY_LINKED` output to the user verbatim — it says what's now shared and
+to commit `.nanopm-company`.
+
+**If COMPANY is already set**, say one line ("This repo is part of {COMPANY}; its
+company docs are shared.") and continue.
+
 ## Phase 1: Detect the mode (refine vs create)
 
 The mode is driven by **one fact: does `BUSINESS-MODEL.md` already exist?** — not by sniffing

--- a/pm-org/SKILL.md
+++ b/pm-org/SKILL.md
@@ -51,6 +51,34 @@ nanopm_context_all
 
 If a prior pm-org entry exists: "Prior org map from {ts}. This run will refine it, not start over."
 
+## Phase 0.5: Link this repo to a company
+
+The company-level docs (mission, business model, org) are **shared** across every
+repo of the same company — you write them once. If this repo isn't linked to a
+company yet, link it now, *before* mode detection (linking is what makes a sibling
+repo's existing company docs visible here).
+
+```bash
+_COMPANY=$(nanopm_company_get)
+echo "COMPANY: ${_COMPANY:-NONE}"
+nanopm_company_list | sed 's/^/  existing-company: /'
+```
+
+**If COMPANY is NONE**, ask via **one** `AskUserQuestion` (header `Company`, ≤12 chars):
+"Which company is this repo for? Its mission, business model & org are shared across
+all repos of that company." Options = each company from `nanopm_company_list`, plus
+**"New company…"** (free-text name). Then link it:
+
+```bash
+nanopm_company_link "<chosen or newly-entered company name>"
+```
+
+Show the `COMPANY_LINKED` output to the user verbatim — it says what's now shared and
+to commit `.nanopm-company`.
+
+**If COMPANY is already set**, say one line ("This repo is part of {COMPANY}; its
+company docs are shared.") and continue.
+
 ## Phase 1: Detect the mode (refine vs create)
 
 The mode is driven by **one fact: does `ORG.md` already exist?** — not by sniffing whatever evidence

--- a/pm-vision-mission/SKILL.md
+++ b/pm-vision-mission/SKILL.md
@@ -52,6 +52,34 @@ nanopm_context_all
 
 If a prior pm-vision-mission entry exists: "Prior vision/mission from {ts}. This run will refine it, not start over."
 
+## Phase 0.5: Link this repo to a company
+
+The company-level docs (mission, business model, org) are **shared** across every
+repo of the same company — you write them once. If this repo isn't linked to a
+company yet, link it now, *before* mode detection (linking is what makes a sibling
+repo's existing company docs visible here).
+
+```bash
+_COMPANY=$(nanopm_company_get)
+echo "COMPANY: ${_COMPANY:-NONE}"
+nanopm_company_list | sed 's/^/  existing-company: /'
+```
+
+**If COMPANY is NONE**, ask via **one** `AskUserQuestion` (header `Company`, ≤12 chars):
+"Which company is this repo for? Its mission, business model & org are shared across
+all repos of that company." Options = each company from `nanopm_company_list`, plus
+**"New company…"** (free-text name). Then link it:
+
+```bash
+nanopm_company_link "<chosen or newly-entered company name>"
+```
+
+Show the `COMPANY_LINKED` output to the user verbatim — it says what's now shared and
+to commit `.nanopm-company`.
+
+**If COMPANY is already set**, say one line ("This repo is part of {COMPANY}; its
+company docs are shared.") and continue.
+
 ## Phase 1: Detect the mode (refine vs create)
 
 The mode is driven by **one fact: does `VISION-MISSION.md` already exist?** — not by sniffing

--- a/viewer/Sources/NanoPMViewer/ArtifactScanner.swift
+++ b/viewer/Sources/NanoPMViewer/ArtifactScanner.swift
@@ -16,7 +16,10 @@ enum ArtifactScanner {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard exists == "yes" else { return .missingNanopm }
 
-        let command = "cd \(ShellRunner.quote(nanopm)) && find . -type f -not -path './.git/*' -exec stat -f '%m|%N' {} \\;"
+        // -L follows symlinks: company-level docs (VISION-MISSION, BUSINESS-MODEL,
+        // ORG) are symlinked into .nanopm/ from the shared ~/.nanopm/companies/<co>/,
+        // so without -L they'd be type `l` and skipped.
+        let command = "cd \(ShellRunner.quote(nanopm)) && find -L . -type f -not -path './.git/*' -exec stat -f '%m|%N' {} \\;"
         let output = try ShellRunner.run(command)
 
         var artifacts: [Artifact] = []


### PR DESCRIPTION
Builds on the inert seam (#27). Company-level docs (mission, business model, org) are now **written once and shared** across every repo of the same company.

## How (the simple version)
Instead of rewriting paths across skills + viewer + brief, the shared docs live once in `~/.nanopm/companies/<slug>/` and are **symlinked into each repo's `.nanopm/`**. So skills, the brief generator, and the viewer keep reading `.nanopm/` unchanged — the docs just appear there and are shared.

- `lib nanopm_company_link` — links the repo (`.nanopm-company`), migrates any existing per-repo company doc up, symlinks the 3 docs in. Idempotent; prints a clear explanation (+ a migration note for existing users).
- The 3 company skills (`pm-vision-mission`, `-business-model`, `-org`) gain a **Phase 0.5: Link this repo to a company** step (ask which company once, then link).
- Viewer: `find` → `find -L` (follow symlinks). **The entire viewer impact — one word.**

## UX
User picks a company once (a click) and commits one tiny `.nanopm-company` file to share. Docs still appear in `.nanopm/` as always — no "where did my docs go" surprise.

## Verified
Two repos of one company genuinely share a doc (edit in B shows in A); existing doc migrates up with a clear note; `find -L` sees the linked docs; refine-mode detection still correct; viewer builds clean; skill-syntax + context-threading suites PASS.

## Known small follow-up
`company_website` is per-project config (from the leak fix) but is arguably company-level — could move to the company folder later. Minor; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)